### PR TITLE
change order to avoid log noise of healthchecks

### DIFF
--- a/backend-go/src/app.go
+++ b/backend-go/src/app.go
@@ -47,12 +47,12 @@ func App() *fiber.App {
 	app.Use(favicon.New())
 	app.Use(recover.New())
 	app.Use(cors.New())
-
+	app.Get("/", HealthCheck)
 	app.Use(logger.New(logger.Config{
 		TimeFormat: "2006-01-02T15:04:05",
 		TimeZone:   "America/Vancouver",
 	}))
-	app.Get("/", HealthCheck)
+	
 	routes.UserRoutes(app)
 	// Serve Swagger documentation
 	app.Get("/swagger/*", swagger.HandlerDefault) // default


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-backends-20-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-backends-20-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-backends-20-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-backends-20-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-backends-20-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge-main.yml)