### PR TITLE
fix: janky cron to avoid asterisks

### DIFF
--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -288,7 +288,7 @@ objects:
         app: "${NAME}-${ZONE}"
         cronjob: "${NAME}-${ZONE}"
     spec:
-      schedule: "${CRON_MINUTES} 8 * * *" # Run daily at 8:xx AM UTC
+      schedule: "${CRON_MINUTES} 8 1-31 1-12 0-6" # Run daily at 8:xx AM UTC
       concurrencyPolicy: "Replace"
       successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
       failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"


### PR DESCRIPTION
Templates with asterisks (`*`) have been expanding improperly.  I'm struggling to escape this cleanly and have sidestepped the issue with ranges.  They're ugly, but easy enough to understand and manage.

e.g. `schedule: "${CRON_MINUTES} 8 1-31 1-12 0-6"`

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://quickstart-openshift-backends-67-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-backends-67-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-backends-67-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-backends-67-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge-main.yml)