### PR TITLE
bug: add labels to HPAs

### DIFF
--- a/backend-go/openshift.deploy.yml
+++ b/backend-go/openshift.deploy.yml
@@ -234,6 +234,8 @@ objects:
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:
+      labels:
+        app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       scaleTargetRef:

--- a/backend-java/openshift.deploy.yml
+++ b/backend-java/openshift.deploy.yml
@@ -171,6 +171,8 @@ objects:
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:
+      labels:
+        app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       scaleTargetRef:

--- a/backend-py/openshift.deploy.yml
+++ b/backend-py/openshift.deploy.yml
@@ -288,6 +288,8 @@ objects:
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:
+      labels:
+        app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       scaleTargetRef:


### PR DESCRIPTION
HorizontalPodAutoscaler objects were excaping cleanup.  Providing a label should fix that.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://quickstart-openshift-backends-80-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-backends-80-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-backends-80-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-backends-80-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge-main.yml)