### PR TITLE
fix: IT, endpoint URLs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -52,11 +52,11 @@ jobs:
         name: [quarkus, fiber, fastapi]
         include:
           - name: quarkus
-            baseUrl: https://quickstart-openshift-backends-test-backend-java.apps.silver.devops.gov.bc.ca
+            baseUrl: https://quickstart-openshift-backends-test-backendJava.apps.silver.devops.gov.bc.ca
           - name: fiber
-            baseUrl: https://quickstart-openshift-backends-test-backend-go.apps.silver.devops.gov.bc.ca
+            baseUrl: https://quickstart-openshift-backends-test-backendGo.apps.silver.devops.gov.bc.ca
           - name: fastapi
-            baseUrl: https://quickstart-openshift-backends-test-backend-py.apps.silver.devops.gov.bc.ca
+            baseUrl: https://quickstart-openshift-backends-test-backendPy.apps.silver.devops.gov.bc.ca
     steps:
       - uses: actions/checkout@v4
         name: Checkout


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-103-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-103-backendPy.apps.silver.devops.gov.bc.ca)
- [Go](https://quickstart-openshift-backends-103-backendGo.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)