### PR TITLE
chore(ci): switch to GH default CodeQL

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -14,58 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  CodeQL:
-    name: CodeQL
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        language: [go, java, python]
-        include:
-          - language: go
-            working-directory: backend-go
-            build: |
-              sed -i '/^toolchain .*$/d' go.mod
-              go install github.com/swaggo/swag/cmd/swag@latest
-              CGO_ENABLED=0 GOOS=linux go build -v
-          - language: "java"
-            working-directory: backend-java
-            build: ./mvnw package -DskipTests
-          - language: "python"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        if: ${{ ! matrix.build }}
-        uses: github/codeql-action/autobuild@v3
-
-      - uses: actions/setup-java@v4
-        if: ${{ matrix.build && matrix.language == 'java' }}
-        with:
-          distribution: "temurin"
-          java-version: "21"
-
-      - uses: actions/cache@v4
-        if: ${{ matrix.build && matrix.language == 'java' }}
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Build
-        if: ${{ matrix.build }}
-        run: ${{ matrix.build }}
-        working-directory: ${{ matrix.working-directory }}
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:${{matrix.language}}"
-
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:
     name: Trivy Security Scan


### PR DESCRIPTION
GitHub default CodeQL has taken over this task.  Our config, which conflicts, is being removed.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-218-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-218-backendPy.apps.silver.devops.gov.bc.ca)
- [Go](https://quickstart-openshift-backends-218-backendGo.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)