### PR TITLE
chore(ci): handle gh runner oc removal

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -70,6 +70,9 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v4
+      - uses: redhat-actions/openshift-tools-installer@v1
+        with:        
+          oc: "4"
       - name: Deploy
         working-directory: ${{ inputs.directory }}
         shell: bash


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-232-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-232-backendPy.apps.silver.devops.gov.bc.ca)
- [Go](https://quickstart-openshift-backends-232-backendGo.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)