### PR TITLE
fix(ci): adjust py CMD as JSON args

### DIFF
--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -17,8 +17,7 @@ FROM python:slim-bookworm AS deploy
 # Output to stdout/stderr, don't create .pyc files, etc.
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PATH="/app/.venv/bin:$PATH" \
-    PORT=3000
+    PATH="/app/.venv/bin:$PATH"
 
 # Packages
 RUN apt update && \
@@ -30,17 +29,16 @@ COPY logger.conf ./
 COPY ./src ./src
 
 # Start with non-privileged user
-HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:${PORT}
+HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
+ENTRYPOINT [ "uvicorn" ]
 CMD [ \
-        "sh", "-c", \
-        "uvicorn", \
         "src.main:app", \
         "--host", "0.0.0.0", \
-        "--port", "${PORT}", \
+        "--port", "3000", \
         "--workers", "1", \
         "--server-header", \
         "--date-header", \
         "--limit-concurrency", "1000", \
         "--log-config", "./logger.conf" \
-]
+    ]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -32,4 +32,14 @@ COPY ./src ./src
 # Start with non-privileged user
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:${PORT}
 USER 1001
-CMD uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf
+CMD [ \
+        "uvicorn", \
+        "src.main:app", \
+        "--host", "0.0.0.0", \
+        "--port", "${PORT}", \
+        "--workers", "1", \
+        "--server-header", \
+        "--date-header", \
+        "--limit-concurrency", "1000", \
+        "--log-config", "./logger.conf" \
+]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -26,6 +26,7 @@ RUN apt update && \
     apt install -y --no-install-recommends curl libpq-dev
 
 # Dependencies, config and app
+WORKDIR /app
 COPY --from=build /app/.venv /app/.venv
 COPY logger.conf ./
 COPY ./src ./src
@@ -34,4 +35,10 @@ COPY ./src ./src
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
 
-CMD ["fastapi", "run", "app/main.py", "--port", "3000"]
+# SSH config
+#
+RUN ( \
+      echo 'uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf'; \
+    ) >> ./entrypoint.sh; \
+    chomd +x ./entrypoint.sh
+CMD ["./entrypoint.sh"]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -11,6 +11,7 @@ COPY pyproject.toml poetry.lock ./
 RUN pip install poetry==1.6.1
 RUN poetry install --no-root -vvv --without dev --sync
 
+
 # Deploy
 FROM python:slim-bookworm AS deploy
 
@@ -32,4 +33,5 @@ COPY ./src ./src
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
 
-CMD ["sh", "-c", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1", "--server-header", "--date-header", "--limit-concurrency", "1000","--log-config", "./logger.conf"]
+# CMD ["sh", "-c", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1", "--server-header", "--date-header", "--limit-concurrency", "1000","--log-config", "./logger.conf"]
+CMD ["fastapi", "run", "app/main.py", "--port", "3000"]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -32,7 +32,7 @@ COPY ./src ./src
 
 # Startup script
 RUN ( \
-        echo 'uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf'; \
+        echo 'uvicorn src.main:app --host 0.0.0.0 --port 3000 --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf'; \
     ) >> ./entrypoint.sh; \
     chmod +x ./entrypoint.sh
 

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -32,8 +32,9 @@ COPY ./src ./src
 
 # Startup script
 RUN ( \
+        echo '#!/bin/sh'; \
         echo 'uvicorn src.main:app --host 0.0.0.0 --port 3000 --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf'; \
-    ) >> ./entrypoint.sh; \
+    ) > ./entrypoint.sh; \
     chmod +x ./entrypoint.sh
 
 # Start with non-privileged user
@@ -41,4 +42,4 @@ HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
 
 # Entrypoint
-CMD ["./entrypoint.sh"]
+CMD ["sh", "-c", "./entrypoint.sh"]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -33,6 +33,7 @@ COPY ./src ./src
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:${PORT}
 USER 1001
 CMD [ \
+        "sh", "-c", \
         "uvicorn", \
         "src.main:app", \
         "--host", "0.0.0.0", \

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN pip install poetry==1.6.1
 RUN poetry install --no-root -vvv --without dev --sync
+RUN pip install fastapi[standard]
 
 
 # Deploy
@@ -33,5 +34,4 @@ COPY ./src ./src
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
 
-# CMD ["sh", "-c", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1", "--server-header", "--date-header", "--limit-concurrency", "1000","--log-config", "./logger.conf"]
 CMD ["fastapi", "run", "app/main.py", "--port", "3000"]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -32,4 +32,4 @@ COPY ./src ./src
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
 
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1", "--server-header", "--date-header", "--limit-concurrency", "1000","--log-config", "./logger.conf"]
+CMD ["sh", "-c", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1", "--server-header", "--date-header", "--limit-concurrency", "1000","--log-config", "./logger.conf"]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN pip install poetry==1.6.1
 RUN poetry install --no-root -vvv --without dev --sync
-RUN pip install fastapi[standard]
 
 
 # Deploy
@@ -31,14 +30,15 @@ COPY --from=build /app/.venv /app/.venv
 COPY logger.conf ./
 COPY ./src ./src
 
+# Startup script
+RUN ( \
+        echo 'uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf'; \
+    ) >> ./entrypoint.sh; \
+    chmod +x ./entrypoint.sh
+
 # Start with non-privileged user
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
 
-# SSH config
-#
-RUN ( \
-      echo 'uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --workers 1 --server-header --date-header --limit-concurrency 1000 --log-config ./logger.conf'; \
-    ) >> ./entrypoint.sh; \
-    chomd +x ./entrypoint.sh
+# Entrypoint
 CMD ["./entrypoint.sh"]

--- a/backend-py/Dockerfile
+++ b/backend-py/Dockerfile
@@ -31,14 +31,5 @@ COPY ./src ./src
 # Start with non-privileged user
 HEALTHCHECK --interval=300s --timeout=10s CMD curl -f http://localhost:3000
 USER 1001
-ENTRYPOINT [ "uvicorn" ]
-CMD [ \
-        "src.main:app", \
-        "--host", "0.0.0.0", \
-        "--port", "3000", \
-        "--workers", "1", \
-        "--server-header", \
-        "--date-header", \
-        "--limit-concurrency", "1000", \
-        "--log-config", "./logger.conf" \
-    ]
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1", "--server-header", "--date-header", "--limit-concurrency", "1000","--log-config", "./logger.conf"]


### PR DESCRIPTION
Code scanning recommends JSON formatting for Dockerfile CMD.  Tiny adjustment.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-250-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-250-backendPy.apps.silver.devops.gov.bc.ca)
- [Go](https://quickstart-openshift-backends-250-backendGo.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)