### PR TITLE
chore: Revert "fix(deps): update dependency uvicorn to ^0.31.0"

### DIFF
--- a/backend-py/poetry.lock
+++ b/backend-py/poetry.lock
@@ -923,14 +923,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.31.0"
+version = "0.30.6"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "uvicorn-0.31.0-py3-none-any.whl", hash = "sha256:cac7be4dd4d891c363cd942160a7b02e69150dcbc7a36be04d5f4af4b17c8ced"},
-    {file = "uvicorn-0.31.0.tar.gz", hash = "sha256:13bc21373d103859f68fe739608e2eb054a816dea79189bc3ca08ea89a275906"},
+    {file = "uvicorn-0.30.6-py3-none-any.whl", hash = "sha256:65fd46fe3fda5bdc1b03b94eb634923ff18cd35b2f084813ea79d1f103f711b5"},
+    {file = "uvicorn-0.30.6.tar.gz", hash = "sha256:4b15decdda1e72be08209e860a1e10e92439ad5b97cf44cc945fcbee66fc5788"},
 ]
 
 [package.dependencies]
@@ -986,4 +986,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "d439e94a00c93a8d7af109abe1ae88844629be31f3c6c5e982afeb666e0fddc6"
+content-hash = "2691877307d1ba16158f9f051cca72ce69edc4a352405e1c1b5891cdb59b5225"

--- a/backend-py/pyproject.toml
+++ b/backend-py/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{ include = "backend_python" }]
 [tool.poetry.dependencies]
 python = "^3.12"
 fastapi = "^0.115.0"
-uvicorn = "^0.31.0"
+uvicorn = "^0.30.6"
 sqlalchemy = "^2.0.32"
 pydantic = {version ="^2.0.0", extras = ["email"]}
 requests = "^2.31.0"


### PR DESCRIPTION
Reverts bcgov/quickstart-openshift-backends#235

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-254-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-254-backendPy.apps.silver.devops.gov.bc.ca)
- [Go](https://quickstart-openshift-backends-254-backendGo.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)