### PR TITLE
fix: pdb pod selector

### DIFF
--- a/charts/app/templates/backendGo/templates/pdb.yaml
+++ b/charts/app/templates/backendGo/templates/pdb.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "backendGo.fullname" . }}
+      app.kubernetes.io/name: {{ include "backendGo.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   minAvailable: {{ .Values.backendGo.pdb.minAvailable }}
 {{- end }}

--- a/charts/app/templates/backendJava/templates/pdb.yaml
+++ b/charts/app/templates/backendJava/templates/pdb.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "backendJava.fullname" . }}
+      app.kubernetes.io/name: {{ include "backendJava.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   minAvailable: {{ .Values.backendJava.pdb.minAvailable }}
 {{- end }}

--- a/charts/app/templates/backendPy/templates/pdb.yaml
+++ b/charts/app/templates/backendPy/templates/pdb.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "backendPy.fullname" . }}
+      app.kubernetes.io/name: {{ include "backendPy.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   minAvailable: {{ .Values.backendPy.pdb.minAvailable }}
 {{- end }}


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-305-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-305-backendPy.apps.silver.devops.gov.bc.ca)
- [Go](https://quickstart-openshift-backends-305-backendGo.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)