### PR TITLE
chore: Potential fix for code scanning alert no. 30: Server-side request forgery

### DIFF
--- a/integration-tests/src/main.js
+++ b/integration-tests/src/main.js
@@ -17,6 +17,33 @@ const __dirname = path.dirname(__filename);
 const apiName = process.env.API_NAME;
 const BASE_URL = process.env.BASE_URL;
 
+// Restrict BASE_URL to an allowlist of URLs or hosts
+const ALLOWED_BASE_URLS = [
+  // List the allowed hosts/endpoints for your testing, e.g.:
+  "https://api.example.com",
+  "https://staging-api.example.com"
+  // Add more as needed
+];
+
+function isAllowedBaseUrl(url) {
+  try {
+    const parsed = new URL(url);
+    // Only allow URLs that start with an allowed base (ignoring trailing slashes)
+    return ALLOWED_BASE_URLS.some(allowed => {
+      // Allow both with/without trailing slash
+      return parsed.href.startsWith(allowed.endsWith("/") ? allowed : allowed + "/") ||
+             parsed.href === allowed;
+    });
+  } catch {
+    return false;
+  }
+}
+
+if (!isAllowedBaseUrl(BASE_URL)) {
+  console.error(`Error: BASE_URL (${BASE_URL}) is not in the allowed list for API testing. Aborting.`);
+  process.exit(1);
+}
+
 async function performEachMethod(BASE_URL, testCase, method, id) {
   let url = BASE_URL + testCase.path;
   if (id && (method === "GET" || method === "PUT" || method === "PATCH" || method === "DELETE")) {


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/quickstart-openshift-backends/security/code-scanning/30](https://github.com/bcgov/quickstart-openshift-backends/security/code-scanning/30)

To mitigate the potential SSRF, restrict the set of acceptable `BASE_URL` values. The best general approach is to maintain an allow-list of known APIs/endpoints that the integration test is permitted to hit, and reject anything else. At minimum, we should verify that `BASE_URL` matches a pattern (e.g., it's a proper https? URL, possibly matches a set of known hosts, and is not pointing at localhost, internal addresses, etc.).

The fix will entail:
- Defining a list of allowed base URLs or hosts at the top of the file.
- Validating `BASE_URL` against this allow-list before running the tests.
  - If it does not match, early-exit the program with an error.
- Optionally, further defensively validate that `testCase.path` does not allow protocol injection or absolute URLs. (Not strictly required if `BASE_URL` is strictly validated and used as a prefix, but a useful extra measure.)

The required imports are already present; only code edits (mostly at the assignment site of `BASE_URL` and before running the tests) are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-394-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-394-backendPy.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)