### PR TITLE
chore: Potential fix for code scanning alert no. 35: Uncontrolled data used in path expression

### DIFF
--- a/backend-java/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/backend-java/.mvn/wrapper/MavenWrapperDownloader.java
@@ -55,6 +55,15 @@ public final class MavenWrapperDownloader
                 System.err.println(" - ERROR: Provided JAR path escapes working directory.");
                 System.exit(1);
             }
+            // Defense-in-depth: resolve symlinks in parent directories
+            Path parentDir = wrapperJarPath.getParent();
+            if (parentDir != null) {
+                Files.createDirectories(parentDir);
+                if (!parentDir.toRealPath().startsWith(baseDir.toRealPath())) {
+                    System.err.println(" - ERROR: Path resolves outside working directory.");
+                    System.exit(1);
+                }
+            }
             downloadFileFromURL( wrapperUrl, wrapperJarPath );
             log( "Done" );
         }


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/quickstart-openshift-backends/security/code-scanning/35](https://github.com/bcgov/quickstart-openshift-backends/security/code-scanning/35)

To remediate this vulnerability, we need to properly restrict the use of the user-supplied path argument so that it cannot be used for path traversal or writing files outside a desired directory.  
- **General Fix:** Normalize the user input, and enforce that it resolves to a path within an intended directory (here, likely the current working directory or a specific subdirectory). Reject any input that is an absolute path, contains path traversal, or otherwise escapes that intended directory.
- **Detailed fix for this context:** After constructing the `jarPath`, create a `Path` object relative to a safe base directory (such as the project root or working directory), resolve the filename, normalize the path, and check that the result is still contained within the intended base directory. If not, throw an exception and abort.
- **Location:** In `main()`, after receiving `args[1]` and before using it to download the file.
- **Imports:** The file already imports the required `java.nio.file` classes.
- **Additional Needs:** Add code to determine the base directory (`Path baseDir = Paths.get("").toAbsolutePath().normalize();`), and compare the resolved file's parent directory with this base. Throw an error if not contained.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-395-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-395-backendPy.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)