### PR TITLE
chore: potential fix for code scanning alert no. 34: Server-side request forgery

### DIFF
--- a/backend-java/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/backend-java/.mvn/wrapper/MavenWrapperDownloader.java
@@ -26,6 +26,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 public final class MavenWrapperDownloader
 {
@@ -38,21 +40,35 @@ public final class MavenWrapperDownloader
         "repo1.maven.org"
     );
 
+    // Pre-compute canonicalized allowed hosts for efficiency
+    private static final java.util.Set<String> CANONICALIZED_ALLOWED_HOSTS = 
+        ALLOWED_MAVEN_REPO_HOSTS.stream()
+            .map(MavenWrapperDownloader::canonicalizeHost)
+            .collect(Collectors.toSet());
+
     /**
      * Canonicalizes the hostname by removing any trailing dots and converting to lowercase.
      * Uses manual string operations instead of regex to avoid ReDoS vulnerabilities.
+     * Returns null for null, empty, or invalid hostnames (e.g., all dots) for security.
+     *
+     * @param host the hostname to canonicalize
+     * @return the canonicalized hostname, or null if host is null, empty, or invalid
      */
     private static String canonicalizeHost(String host) {
-        if (host == null) {
-            return "";
+        if (host == null || host.isEmpty()) {
+            return null;
         }
         // Remove trailing dots manually (more efficient than regex, avoids ReDoS)
         int endIndex = host.length();
         while (endIndex > 0 && host.charAt(endIndex - 1) == '.') {
             endIndex--;
         }
-        // Convert to lowercase
-        return host.substring(0, endIndex).toLowerCase();
+        // Check if hostname was all dots
+        if (endIndex == 0) {
+            return null; // hostname was all dots
+        }
+        // Convert to lowercase using ROOT locale for consistent behavior across all locales
+        return host.substring(0, endIndex).toLowerCase(Locale.ROOT);
     }
 
     public static void main( String[] args )
@@ -109,7 +125,12 @@ public final class MavenWrapperDownloader
 
     /**
      * Validates that the given URL is allowed for downloading Maven wrapper.
-     * Only HTTPS protocol is allowed and the host must be in the list of allowed Maven repository hosts.
+     * Only HTTPS protocol is allowed and the host must exactly match (after canonicalization)
+     * one of the allowed Maven repository hosts. This prevents SSRF attacks by:
+     * - Requiring exact host match (no subdomains)
+     * - Canonicalizing hostnames (removing trailing dots, normalizing case)
+     * - Restricting to HTTPS only
+     * - Rejecting null, empty, or invalid hostnames
      *
      * @param url the URL to validate
      * @return true if the URL is allowed, false otherwise
@@ -121,10 +142,12 @@ public final class MavenWrapperDownloader
             return false;
         }
         String actualHost = canonicalizeHost(url.getHost());
-        // No subdomain allowed, just exact host match.
-        return ALLOWED_MAVEN_REPO_HOSTS.stream()
-            .map(MavenWrapperDownloader::canonicalizeHost)
-            .anyMatch(h -> h.equals(actualHost));
+        // Reject null or invalid hostnames
+        if (actualHost == null) {
+            return false;
+        }
+        // No subdomain allowed, just exact host match using pre-computed canonicalized hosts.
+        return CANONICALIZED_ALLOWED_HOSTS.contains(actualHost);
     }
 
     private static void downloadFileFromURL( URL wrapperUrl, Path wrapperJarPath )


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/quickstart-openshift-backends/security/code-scanning/34](https://github.com/bcgov/quickstart-openshift-backends/security/code-scanning/34)

The best way to fix the SSRF risk is to make the URL validation more robust and ensure that even tricky edge cases (e.g., subdomains, mixed case, trailing dots, etc.) are handled. Specifically:

1. Canonicalize the hostname before comparison, stripping any trailing dots, converting to lowercase, and rejecting any use of subdomains or alternate forms.
2. Optionally, you could restrict to a specific path or URL prefix, but for Maven repositories the host is likely sufficient.
3. Edit the `isAllowedUrl` method in `.mvn/wrapper/MavenWrapperDownloader.java` to:
   - Canonicalize both the incoming URL host and allowed hosts.
   - Prevent the use of subdomains (i.e., require exact match).
   - Optionally, reject the use of alternate forms of hostnames (such as Unicode).
4. You may add a helper function to canonicalize hostnames if necessary.

All code edits are restricted to the shown `.mvn/wrapper/MavenWrapperDownloader.java` code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Java](https://quickstart-openshift-backends-398-backendJava.apps.silver.devops.gov.bc.ca)
- [Py](https://quickstart-openshift-backends-398-backendPy.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-backends/actions/workflows/merge.yml)